### PR TITLE
rename new-window-closed icon, should be 'close'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This file follows the format suggested by [Keep a CHANGELOG](https://github.com/
 
 ## [Unreleased][Unreleased]
 
+## [2.0.0][2.0.0] - 2016-04-06
+### Changed
+- [Release] Change `24/toolbar-new-window-closed-24` icon to `24/toolbar-new-window-close-24`.
+
 ## [1.1.3][1.1.3] - 2016-04-04
 ### Changed
 - [Patch] Change `winner` and `loser` icons.
@@ -69,3 +73,4 @@ Initial version.
 [1.1.1]: https://github.com/optimizely/oui-icons/compare/v1.1.0...v1.1.1
 [1.1.2]: https://github.com/optimizely/oui-icons/compare/v1.1.1...v1.1.2
 [1.1.3]: https://github.com/optimizely/oui-icons/compare/v1.1.2...v1.1.3
+[2.0.0]: https://github.com/optimizely/oui-icons/compare/v1.1.3...v2.0.0

--- a/src/24/toolbar-new-window-close-24.svg
+++ b/src/24/toolbar-new-window-close-24.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
-<!-- Generator: Adobe Illustrator 19.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!-- Generator: Adobe Illustrator 18.1.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1 Tiny//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11-tiny.dtd">
 <svg version="1.1" baseProfile="tiny" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
 	 x="0px" y="0px" viewBox="0 0 24 24" xml:space="preserve">


### PR DESCRIPTION
@danoc & @daverau-optimizely we have an icon called `toolbar-new-window-closed-24.svg` in here currently. But the app references it as `toolbar-new-window-close-24.svg` which I think is a better name.

Rather than renaming the icon in the app to add the `d`, I'd rather remove the `d` from the icon name in this repo. Let me know what you guys think.

Also, let me know if this should be released as patch / minor or what, I know this is a breaking (or 'fixing') change but it's also kinda like a bug..
